### PR TITLE
Add images and captions to the meeting summaries html and markdown files

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -11,6 +11,7 @@ env/
 # Generated files from the pipeline
 *.txt
 *.xlsx
+*.png
 *.html
 *.vtt
 *.md

--- a/pipeline.py
+++ b/pipeline.py
@@ -198,6 +198,9 @@ def run_pipeline(input_file, video_id=None, skip_refinement=False, html_format="
         sys.exit(1)
     
     # Step 3: Run refineStartTimes if not skipped
+    # for each entry that has a topic and topic text 
+    # find the most well-matching entry corresponding to that topic with the same speaker 
+    # and mark the entry in refineStartTimes
     refined_xlsx_file = xlsx_file
     if not skip_refinement:
         logger.info("Step 3: Refining start times...")

--- a/refineStartTimes.py
+++ b/refineStartTimes.py
@@ -203,7 +203,7 @@ def refine_start_times(xlsx_file, output_file=None):
             if col in df.columns and pd.api.types.is_numeric_dtype(df[col].dtype):
                 df[col] = df[col].astype('object')
         
-        # Process each topic
+        # Process each topic by index retrieved for rows where df['Topic'] is not empty
         for idx in topic_rows:
             topic = df.loc[idx, 'Topic']
             speaker = df.loc[idx, 'Name']

--- a/utils.py
+++ b/utils.py
@@ -530,3 +530,114 @@ def get_api_key():
                 print(f"Error saving API key: {e}")
     
     return api_key
+
+## Utilities for Panopto video screenshotting
+
+
+from typing import Union, Optional
+from PIL import Image
+from playwright.sync_api import sync_playwright
+import io, time
+
+def screenshot_panopto_as_image(
+    video_id: str, 
+    start_sec: int,
+    timeout_sec: int = 30,
+    max_retries: int = 3,
+    viewport_size: dict = {"width": 1920, "height": 1080},
+    headless: bool = True,
+    resize_scale: float = 0.5
+) -> Optional[Union[bytes, Image.Image]]:
+    """
+    Spin up a headless browser, go to the Panopto Viewer, wait for the network
+    to quiet down and the UI to render, then snapshot the whole page.
+    """
+    url = (
+        f"https://mit.hosted.panopto.com/Panopto/Pages/Viewer.aspx"
+        f"?id={video_id}&start={start_sec}"
+    )
+
+    for attempt in range(1, max_retries+1):
+        try:
+            with sync_playwright() as pw:
+                browser = pw.chromium.launch(
+                    # headless=headless,
+                    channel="chrome",
+                    headless=headless,
+                    args=["--no-sandbox","--disable-gpu", "--disable-blink-features=AutomationControlled",]
+                )
+
+                # Create a context with the desired viewport
+                context = browser.new_context(viewport=viewport_size)
+                page = context.new_page()                
+                page.set_default_timeout(timeout_sec * 1000)
+                page.add_init_script(
+                    "Object.defineProperty(navigator, 'webdriver', {get:() => undefined});"
+                )
+
+                # Navigate to the video page
+                page.goto(url, wait_until="domcontentloaded")
+                page.wait_for_load_state("networkidle")
+
+                page.wait_for_function("""
+                () => {
+                    const v = document.getElementById('secondaryVideo');
+                    return v && v.readyState >= 3;
+                }
+                """, timeout=timeout_sec * 1000)
+
+                # press play button
+                page.wait_for_selector('#playButton', timeout=timeout_sec * 1000)
+                page.click('#playButton')
+                
+                # Wait for video element to be available
+                page.wait_for_selector("video#primaryVideo", state="attached", timeout=timeout_sec * 1000)
+                page.wait_for_selector("video#secondaryVideo", state="attached", timeout=timeout_sec * 1000)
+
+                # Wait for video to be ready and seek to exact timestamp
+                page.wait_for_function("""
+                    async (targetTime) => {
+                        const video = document.getElementById('secondaryVideo');
+                        if (!video) return false;
+                        
+                        // Wait for video to be ready
+                        if (video.readyState < 3) return false;
+                        
+                        // Seek to exact timestamp
+                        video.currentTime = targetTime;
+                        await new Promise(r => setTimeout(r, 100)); // Small delay to ensure seek completes
+                        video.play() 
+                        video.pause()                
+                        // Verify we're at the correct timestamp
+                        return Math.abs(video.currentTime - targetTime) < 0.1;
+                    }
+                """, arg=start_sec, timeout=timeout_sec * 1000)
+
+                # Take screenshot immediately after seeking
+                png_bytes = page.screenshot(full_page=True)
+                browser.close()
+
+                img = Image.open(io.BytesIO(png_bytes))
+                img = img.resize((int(img.width * resize_scale), int(img.height * resize_scale)))
+                return img
+
+        except Exception as e:
+            print(f"Attempt {attempt} failed: {e}")
+            if attempt == max_retries:
+                return None
+            # exponential backoff
+            time.sleep(2 ** attempt)
+
+    return None
+
+
+
+if __name__ == "__main__":
+    # test link is https://mit.hosted.panopto.com/Panopto/Pages/Viewer.aspx?id=fb0e4313-e23f-4bad-ac1b-b2df000331b2&start=1000 
+    # and seconds to test is 200 and 1000 
+    seconds_to_test = [100, 1000]
+    for seconds in seconds_to_test:
+        image = screenshot_panopto_as_image("fb0e4313-e23f-4bad-ac1b-b2df000331b2", seconds)
+        # save image to file
+        image.save(f"test_screenshot_{seconds}.png")
+        print(f"Saved test_screenshot_{seconds}.png")


### PR DESCRIPTION
## Description

This PR adds the functionality of adding relevant screenshots of the panopto recording for each time interval of the meeting summaries that is generated in xlxs2html.py. Functions of "evaluate_candidate_image_timesteps_across_all_batches" has been added which iterates across all batches and creates a dictionary to store for each topic and the time interval the corresponding images and captions to be displayed. There can be at most 3 images that can be shown for each topic and time interval. "Embed_with_candidate_image_timesteps_batch" finds 5 potential distinct timestamps for each time interval that can likely provide meaningful visual screenshots for that corresponding topic and time interval. 

## Motivation and context

This allows visual summaries of the meeting summaries by also adding screenshot. 


## How has this been tested?
The function has been tested with video links of varying length (~40 minutes and ~2 hours) and correctly generate images.

## Types of changes

- ✅ New feature (non-breaking change which adds functionality)
